### PR TITLE
Remove unneeded cache on staging workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-          cache: 'gradle'
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
Running `flutter analyze` doesn't need gradle, so we should skip fetching and saving its cache to save time on this workflow.